### PR TITLE
[Fix] -  Query of count leaderboard not use year 

### DIFF
--- a/django/mathias/settings/base.py
+++ b/django/mathias/settings/base.py
@@ -2,7 +2,7 @@ import os
 from decouple import config
 
 DEBUG = config('DEBUG', default=False, cast=bool)
-VERSION = '1.1.2'
+VERSION = '1.1.3'
 
 ADMINS = (
 

--- a/django/mathias/valeu/core/mysql_count_valeu.py
+++ b/django/mathias/valeu/core/mysql_count_valeu.py
@@ -7,7 +7,7 @@ def query(user_name_from):
     return """
         select count(1) as points, v.user_name_to
           from valeu v
-        where month(v.create_at) = month(now())
+        where ((month(v.create_at)  = month(now())) and (year(v.create_at) = year(now())))
         and v.user_name_to = '{user_name_from}'
           group by v.user_name_to
     """.format(**params)


### PR DESCRIPTION
### CHANGELOG:
	
- The query of count leaderboard not filter using year and the count to get `valeus` of years old

